### PR TITLE
fix: Add props for customising buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,21 @@ function MyComponent() {
 }
 ```
 
-| Property              | Default Value | Usage                     |
-| --------------------- | ------------- | ------------------------- |
-| children?: string     |               | Content                   |
-| visible?: boolean     |               | Show modal                |
-| showClose?: boolean   |               | Show close button         |
-| width?: number        |               | Width of the modal        |
-| onClose?: () => void  |               | On close modal            |
-| onOk?: () => void     |               | On click on ok button     |
-| onCancel?: () => void |               | On click on cancel button |
-| okText?: string       | OK            | Label of ok button        |
-| cancelText?: string   | Cancel        | Label of cancel button    |
+| Property                              | Default Value | Usage                             |
+| ------------------------------------- | ------------- | --------------------------------- |
+| children?: string                     |               | Content                           |
+| visible?: boolean                     |               | Show modal                        |
+| showClose?: boolean                   |               | Show close button                 |
+| width?: number                        |               | Width of the modal                |
+| onClose?: () => void                  |               | On close modal                    |
+| onOk?: () => void                     |               | On click on ok button             |
+| onCancel?: () => void                 |               | On click on cancel button         |
+| okText?: string                       | OK            | Label of ok button                |
+| okButtonBackgroundColor?: string      |               | Background color of ok button     |
+| okTextColor?: string                  |               | Text color of ok button           |
+| cancelText?: string                   | Cancel        | Label of cancel button            |
+| cancelButtonBackgroundColor?: string  |               | Background color of cancel button |
+| cancelTextColor?: string              |               | Text color of cancel button       |
 
 ## Automatic Release
 

--- a/src/confirmation-modal.tsx
+++ b/src/confirmation-modal.tsx
@@ -10,6 +10,7 @@ interface Props extends ModalProps {
   children?: string
   okText?: string
   cancelText?: string
+  okButtonBackgroundColor?: string
   onOk?: () => void
   onCancel?: () => void
   onClose?: () => void
@@ -19,6 +20,7 @@ export function ConfirmationModal({
   children,
   okText = 'OK',
   cancelText = 'Cancel',
+  okButtonBackgroundColor = COLOR.ACCENT,
   onOk,
   onCancel,
   onClose,
@@ -51,7 +53,7 @@ export function ConfirmationModal({
           {cancelText}
         </Button>
         <Spacer size='small' />
-        <Button backgroundColor={COLOR.ACCENT} onTap={handleOk} rounded size='small' width={100}>
+        <Button backgroundColor={okButtonBackgroundColor} onTap={handleOk} rounded size='small' width={100}>
           {okText}
         </Button>
       </Stack>

--- a/src/confirmation-modal.tsx
+++ b/src/confirmation-modal.tsx
@@ -11,6 +11,7 @@ interface Props extends ModalProps {
   okText?: string
   cancelText?: string
   okButtonBackgroundColor?: string
+  cancelButtonBackgroundColor?: string
   onOk?: () => void
   onCancel?: () => void
   onClose?: () => void
@@ -21,6 +22,7 @@ export function ConfirmationModal({
   okText = 'OK',
   cancelText = 'Cancel',
   okButtonBackgroundColor = COLOR.ACCENT,
+  cancelButtonBackgroundColor = COLOR.SECONDARY,
   onOk,
   onCancel,
   onClose,
@@ -44,7 +46,7 @@ export function ConfirmationModal({
       <Spacer size='small' />
       <Stack horizontal justifyBetween>
         <Button
-          backgroundColor={COLOR.SECONDARY}
+          backgroundColor={cancelButtonBackgroundColor}
           onTap={handleCancel}
           rounded
           size='small'

--- a/src/confirmation-modal.tsx
+++ b/src/confirmation-modal.tsx
@@ -11,7 +11,9 @@ interface Props extends ModalProps {
   okText?: string
   cancelText?: string
   okButtonBackgroundColor?: string
+  okTextColor?: string
   cancelButtonBackgroundColor?: string
+  cancelTextColor?: string
   onOk?: () => void
   onCancel?: () => void
   onClose?: () => void
@@ -23,6 +25,8 @@ export function ConfirmationModal({
   cancelText = 'Cancel',
   okButtonBackgroundColor = COLOR.ACCENT,
   cancelButtonBackgroundColor = COLOR.SECONDARY,
+  okTextColor,
+  cancelTextColor,
   onOk,
   onCancel,
   onClose,
@@ -51,11 +55,19 @@ export function ConfirmationModal({
           rounded
           size='small'
           width={100}
+          textColor={cancelTextColor}
         >
           {cancelText}
         </Button>
         <Spacer size='small' />
-        <Button backgroundColor={okButtonBackgroundColor} onTap={handleOk} rounded size='small' width={100}>
+        <Button
+          backgroundColor={okButtonBackgroundColor}
+          onTap={handleOk}
+          rounded
+          size='small'
+          width={100}
+          textColor={okTextColor}
+        >
           {okText}
         </Button>
       </Stack>


### PR DESCRIPTION
Adds the following props:
- [x] `okButtonBackgroundColor`
- [x] `cancelButtonBackgroundColor`
- [x] `okTextColor`
- [x] `cancelTextColor`