### PR TITLE
fix: Allow modal to be dismissed by clicking on backdrop

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -3,6 +3,7 @@ import { COLOR, ContainerStyleProps } from 'native-x-theme'
 import React from 'react'
 import { Platform } from 'react-native'
 import RNModal from 'react-native-modal'
+import { styles as s } from 'tachyons-react-native'
 import { ModalCloseButton } from './modal-close-button'
 import { ModalOverlay } from './modal-overlay'
 
@@ -15,6 +16,13 @@ export interface ModalProps extends ContainerStyleProps {
 }
 
 export function Modal({ children, visible, onClose, width, showClose, ...props }: ModalProps) {
+  const styles = React.useMemo(
+    () => ({
+      container: [s.selfCenter, { width: width ?? 'fit-content' }] as any,
+    }),
+    [width],
+  )
+
   return (
     <RNModal
       coverScreen
@@ -27,18 +35,17 @@ export function Modal({ children, visible, onClose, width, showClose, ...props }
       avoidKeyboard
       customBackdrop={<ModalOverlay />}
     >
-      <Stack fill alignCenter alignMiddle>
-        <Stack
-          alignCenter
-          alignMiddle
-          backgroundColor={COLOR.PRIMARY}
-          borderRadius='large'
-          width={width}
-          {...props}
-        >
-          {children}
-          {showClose && <ModalCloseButton onTap={onClose} />}
-        </Stack>
+      <Stack
+        alignCenter
+        alignMiddle
+        backgroundColor={COLOR.PRIMARY}
+        borderRadius='large'
+        width={width}
+        style={styles.container}
+        {...props}
+      >
+        {children}
+        {showClose && <ModalCloseButton onTap={onClose} />}
       </Stack>
     </RNModal>
   )

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -33,7 +33,7 @@ export function Modal({ children, visible, onClose, width, showClose, ...props }
       useNativeDriver={Platform.OS !== 'web'}
       useNativeDriverForBackdrop={Platform.OS !== 'web'}
       avoidKeyboard
-      customBackdrop={<ModalOverlay />}
+      customBackdrop={<ModalOverlay onTap={Platform.OS == 'web' ? onClose : undefined} />}
     >
       <Stack
         alignCenter


### PR DESCRIPTION
## Description

Taps on modal backdrop were not getting registered because of a wrapping view.

### Change log

- Removed the wrapper view which stretched across the backdrop
- Pass down onClose callback for ModalOverlay on web platform