### PR TITLE
refactor: Avoid keyboard conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ function MyComponent() {
 
 ## API
 
-| Property             | Default Value | Usage              |
-| -------------------- | ------------- | ------------------ |
-| children?: string    |               | Content            |
-| visible?: boolean    |               | Show modal         |
-| showClose?: boolean  |               | Show close button  |
-| width?: number       |               | Width of the modal |
-| onClose?: () => void |               | On close modal     |
+| Property                | Default Value | Usage                 |
+| ----------------------- | ------------- | --------------------- |
+| children?: string       |               | Content               |
+| visible?: boolean       |               | Show modal            |
+| showClose?: boolean     |               | Show close button     |
+| width?: number          |               | Width of the modal    |
+| onClose?: () => void    |               | On close modal        |
+| avoidKeyboard?: boolean |               | Should avoid keyboard |
 
 ## Confirmation Modal
 
@@ -71,6 +72,7 @@ function MyComponent() {
 | showClose?: boolean                  |               | Show close button                 |
 | width?: number                       |               | Width of the modal                |
 | onClose?: () => void                 |               | On close modal                    |
+| avoidKeyboard?: boolean              |               | Should avoid keyboard             |
 | onOk?: () => void                    |               | On click on ok button             |
 | onCancel?: () => void                |               | On click on cancel button         |
 | okText?: string                      | OK            | Label of ok button                |

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -11,6 +11,7 @@ export interface ModalProps extends ContainerStyleProps {
   children?: any
   visible?: boolean
   showClose?: boolean
+  avoidKeyboard?: boolean
   onClose?: () => void
   width?: number
 }
@@ -19,7 +20,15 @@ const styles = {
   container: [s.selfCenter] as ViewStyle,
 }
 
-export function Modal({ children, visible, onClose, width, showClose, ...props }: ModalProps) {
+export function Modal({
+  children,
+  visible,
+  onClose,
+  width,
+  showClose,
+  avoidKeyboard,
+  ...props
+}: ModalProps) {
   return (
     <RNModal
       coverScreen
@@ -29,7 +38,7 @@ export function Modal({ children, visible, onClose, width, showClose, ...props }
       backdropOpacity={Platform.OS !== 'web' ? 1 : undefined}
       useNativeDriver={Platform.OS !== 'web'}
       useNativeDriverForBackdrop={Platform.OS !== 'web'}
-      avoidKeyboard
+      avoidKeyboard={avoidKeyboard}
       customBackdrop={<ModalOverlay onTap={Platform.OS == 'web' ? onClose : undefined} />}
     >
       <Stack


### PR DESCRIPTION
### Changelog 

- expose `avoidKeyboard` as a prop
- remove default value of `avoidKeyboard` as `true`.